### PR TITLE
Avoids erroring out when parsing shows with no episode

### DIFF
--- a/single.py
+++ b/single.py
@@ -73,10 +73,15 @@ class RaiParser:
         except KeyError:
             pass
         feed._data[f"{NSITUNES}category"] = [{"@text": c} for c in categories]
-        feed.update = _datetime_parser(rdata["block"]["update_date"])
+        cards = []
+        try:
+            feed.update = _datetime_parser(rdata["block"]["update_date"])
+            cards = rdata["block"]["cards"]
+        except KeyError:
+            pass
         if not feed.update:
             feed.update = _datetime_parser(rdata["track_info"]["date"])
-        for item in rdata["block"]["cards"]:
+        for item in cards:
             if "/playlist/" in item.get("weblink", ""):
                 self.extend(item["weblink"])
             if not item.get("audio", None):


### PR DESCRIPTION
Before this change show like
`https://www.raiplaysound.it/programmi/crossover-lamusicaa360giri` failed to parse as the retrieved json lacks the `block` element

Now the script do not print a stacktrace and skips the program

Stacktrace looked like:

```python
 python3 single.py https://www.raiplaysound.it/programmi/crossover-lamusicaa360giri --programma
Traceback (most recent call last):
  File "/raiplaysound/single.py", line 239, in <module>
    main()
  File "/raiplaysound/single.py", line 230, in main
    parser.process(
  File "/raiplaysound/single.py", line 133, in process
    self._json_to_feed(feed, rdata)
  File "/raiplaysound/single.py", line 76, in _json_to_feed
    feed.update = _datetime_parser(rdata["block"]["update_date"])
                                   ~~~~~^^^^^^^^^
KeyError: 'block'
```